### PR TITLE
Use "default" as the default "username"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,29 @@ While the Kitchenplan wrapper uses a Ruby gem and quite some code, I kept Superl
 
 Start by forking [superlumic-config](https://github.com/superlumic/superlumic-config). This is the default configuration "role" for Superlumic and will serve as a starting point for your own configuration.
 
-You will need at least a "username.yml" playbook, where you replace "username" by the username you will run Superlumic as on your mac. Use the roles folder to create "profiles" and add extra dependencies in the "requirements.yml" as needed.
+You will need at least a "default.yml" playbook. Use the roles folder to create "profiles" and add extra dependencies in the "requirements.yml" as needed.
 
-How you organise your config files is entirely up to you, but this is how I do it. The "profile-all" role are the apps and settings that everyone in my company needs. Then I have a group file per type of installation (developers, designers, etc). In the "username.yml" playbook I then add all the specific things for that user.
+How you organise your config files is entirely up to you, but this is how I do it. The "profile-all" role are the apps and settings that everyone in my company needs. Then I have a group file per type of installation (developers, designers, etc). You can then create a "username.yml" playbook to add all the specific things for a specific user.
 
 ## Running Superlumic
 
-```
+```bash
 curl -s https://raw.githubusercontent.com/superlumic/superlumic/master/superlumic | bash -s <your repo clone url here>
 ```
 
 Or if you have an adversion to piping scripts over the internet into bash, download the [Superlumic script](https://raw.githubusercontent.com/superlumic/superlumic/master/superlumic) and run it.
 
+**Note:** Superlumic takes in an additional, optional, argument that determines the name of the playbook to use. When no argument is supplied, "default.yml" will be used. However, if you ran the script thusly:
+
+```bash
+curl -s https://raw.githubusercontent.com/superlumic/superlumic/master/superlumic | bash -s <your repo clone url here> roderik
+```
+
+Then "roderik.yml" will be used.
+
 ## Out of the box result?
 
-Starting from "roderik.yml" this will get you:
+Starting from "default.yml" this will get you:
 
 * All my favorite GUI apps installed via Homebrew Cask
 * All my favorite commandline apps installed via Homebrew

--- a/superlumic
+++ b/superlumic
@@ -112,7 +112,7 @@ else
         git clone -q $repo /usr/local/superlumic/config
     else
         setStatusMessage "Getting the default config"
-        git clone -q https://github.com/klarna/superlumic-config.git /usr/local/superlumic/config
+        git clone -q https://github.com/grozen/superlumic-config.git /usr/local/superlumic/config
     fi
 fi
 

--- a/superlumic
+++ b/superlumic
@@ -112,7 +112,7 @@ if [ -d "/usr/local/superlumic/config" ]; then
 else
     if [ ! -z "$repo" ]; then
         setStatusMessage "Getting your config from your fork"
-        git clone -q $1 /usr/local/superlumic/config
+        git clone -q $repo /usr/local/superlumic/config
     else
         setStatusMessage "Getting the default config"
         git clone -q https://github.com/superlumic/superlumic-config.git /usr/local/superlumic/config

--- a/superlumic
+++ b/superlumic
@@ -130,10 +130,5 @@ if [ -f "config/$username.yml" ]; then
     setStatusMessage "Running the ansible playbook for $username"
     ansible-playbook -i "localhost," config/$username.yml
 else
-    if [ "travis" = "$username" ]; then
-        setStatusMessage "Running the ansible playbook for $username but use default.yml as fallback"
-        ansible-playbook -i "localhost," config/default.yml
-    else
-        triggerError "No playbook for $username found"
-    fi
+    triggerError "No playbook for $username found"
 fi

--- a/superlumic
+++ b/superlumic
@@ -131,8 +131,8 @@ if [ -f "config/$username.yml" ]; then
     ansible-playbook -i "localhost," config/$username.yml
 else
     if [ "travis" = "$username" ]; then
-        setStatusMessage "Running the ansible playbook for $username but use roderik.yml as fallback"
-        ansible-playbook -i "localhost," config/roderik.yml
+        setStatusMessage "Running the ansible playbook for $username but use default.yml as fallback"
+        ansible-playbook -i "localhost," config/default.yml
     else
         triggerError "No playbook for $username found"
     fi

--- a/superlumic
+++ b/superlumic
@@ -21,10 +21,7 @@ sudo -v
 export ANSIBLE_ASK_SUDO_PASS=True
 
 repo=$1
-username=$USER
-if [ ! -z "$2" ]; then
-    username=$2
-fi
+username=${2-default}
 
 function triggerError {
     printf "${BRed} --> $1 ${Color_Off}\n" 1>&2

--- a/superlumic
+++ b/superlumic
@@ -112,7 +112,7 @@ else
         git clone -q $repo /usr/local/superlumic/config
     else
         setStatusMessage "Getting the default config"
-        git clone -q https://github.com/superlumic/superlumic-config.git /usr/local/superlumic/config
+        git clone -q https://github.com/klarna/superlumic-config.git /usr/local/superlumic/config
     fi
 fi
 

--- a/superlumic
+++ b/superlumic
@@ -128,7 +128,7 @@ ansible-galaxy install -f -r config/requirements.yml -p roles
 
 if [ -f "config/$username.yml" ]; then
     setStatusMessage "Running the ansible playbook for $username"
-    ansible-playbook -i "localhost," config/$username.yml
+    ansible-playbook -i "localhost," --ask-sudo-pass config/$username.yml
 else
     triggerError "No playbook for $username found"
 fi


### PR DESCRIPTION
Created this to partially resolve #3.
I do suspect the common usecase is that people will want superlumic to be as useable out of the box as possible. Using "default.yml" as the default playbook will allow that, as setting up a sufficiently good "default.yml" in a fork of superlumic-config won't necessitate each user running it to create a YAML config for his specific username.

I obviously mean no offense by not having the default file stay "roderik.yml", but I believe something more neutral would be less confusing.
