### PR TITLE
Install issue while I decide to change repo url

### DIFF
--- a/superlumic
+++ b/superlumic
@@ -107,7 +107,8 @@ sudo chgrp -R admin /usr/local
 
 if [ -d "/usr/local/superlumic/config" ]; then
     setStatusMessage "Update your config from git"
-    cd /usr/local/superlumic/config
+    rm -f /usr/local/superlumic/config
+    git clone -q $1 /usr/local/superlumic/config
     git pull -q
 else
     if [ ! -z "$repo" ]; then


### PR DESCRIPTION
curl -s https://raw.githubusercontent.com/superlumic/superlumic/master/superlumic | bash -s <your repo clone url here>

Problem comes when I decide to change the <repo url>, this script will still use my former one. so I think it might be better to force the config repo reload first.
